### PR TITLE
fix: Ignore internal interfaces when probing routes (VPNs)

### DIFF
--- a/.changeset/fair-cows-perform.md
+++ b/.changeset/fair-cows-perform.md
@@ -1,0 +1,5 @@
+---
+'lan-network': patch
+---
+
+When matching a probed route, ignore internal interfaces. The probed route will match a VPN (virtual) interface when using it to tunnel all traffic, but is unlikely to be considered the local network by users.

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,10 @@ export async function lanNetwork(): Promise<GatewayAssignment> {
   try {
     const defaultRoute = await probeDefaultRoute();
     // If this route matches a known assignment, return it without a gateway
-    if ((assignment = matchAssignment(assignments, defaultRoute))) {
+    if (
+      (assignment = matchAssignment(assignments, defaultRoute)) &&
+      assignment.internal
+    ) {
       return assignment;
     }
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_ASSIGNMENT,
   interfaceAssignments,
   matchAssignment,
+  isInternal,
 } from './network';
 import type { GatewayAssignment } from './types';
 
@@ -28,7 +29,7 @@ export async function lanNetwork(): Promise<GatewayAssignment> {
     // If this route matches a known assignment, return it without a gateway
     if (
       (assignment = matchAssignment(assignments, defaultRoute)) &&
-      assignment.internal
+      !isInternal(assignment)
     ) {
       return assignment;
     }

--- a/src/network.ts
+++ b/src/network.ts
@@ -45,6 +45,10 @@ const getSubnetPriority = (addr: string): number => {
   else return 0;
 };
 
+/** Determines if an assignment is internal (indicated by the flag or by a zeroed mac address) */
+export const isInternal = (assignment: NetworkAssignment) =>
+  assignment.internal || parseMacStr(assignment.mac).every(x => !x);
+
 export const interfaceAssignments = (): NetworkAssignment[] => {
   const candidates: NetworkAssignment[] = [];
   const interfaces = os.networkInterfaces();
@@ -62,7 +66,7 @@ export const interfaceAssignments = (): NetworkAssignment[] => {
     // Prioritise external interfaces, then sort by priority,
     // when priority is equal, sort by raw IP values
     const sortBy =
-      +a.internal - +b.internal ||
+      +isInternal(a) - +isInternal(b) ||
       priorityB - priorityA ||
       parseIpStr(b.address) - parseIpStr(a.address);
     return sortBy;


### PR DESCRIPTION
## Summary

When matching we're prioritising the default probed route over the sorting method. However, when a user is connected to a VPN that acts to tunnel all traffic, the default probed route will point at a virtual interface. If the VPN isn't used for development but only public network access, it's unlikely to be the desirable determined route by users, so we should ignore it.

Additionally, it seems like `internal` is not detected correctly and we also need to check the MAC address of interfaces. An inteface is now detected and treated as internal when:
- the flag is set to `internal`
- or the MAC address is zeroed out

## Set of changes

- Ignore internal interfaces for probed route results
- When sorting default network interfaces, treat zeroed MAC addresses as internal