### PR TITLE
fix: Fix probe and fallback method for Windows

### DIFF
--- a/.changeset/funny-sloths-joke.md
+++ b/.changeset/funny-sloths-joke.md
@@ -1,0 +1,5 @@
+---
+'lan-network': patch
+---
+
+Fix probing and fallback methods for Windows

--- a/src/network.ts
+++ b/src/network.ts
@@ -56,6 +56,9 @@ export const isInternal = (assignment: NetworkAssignment) => {
   } else if (mac[0] === 0 && mac[1] === 21 && mac[2] === 93) {
     // NOTE(@kitten): Microsoft virtual interface
     return true;
+  } else if (assignment.iname.includes('vEthernet')) {
+    // NOTE(@kitten): Other Windows virtual interfaces
+    return true;
   } else {
     return false;
   }

--- a/src/network.ts
+++ b/src/network.ts
@@ -46,8 +46,20 @@ const getSubnetPriority = (addr: string): number => {
 };
 
 /** Determines if an assignment is internal (indicated by the flag or by a zeroed mac address) */
-export const isInternal = (assignment: NetworkAssignment) =>
-  assignment.internal || parseMacStr(assignment.mac).every(x => !x);
+export const isInternal = (assignment: NetworkAssignment) => {
+  if (assignment.internal) {
+    return true;
+  }
+  const mac = parseMacStr(assignment.mac);
+  if (mac.every(x => !x)) {
+    return true;
+  } else if (mac[0] === 0 && mac[1] === 21 && mac[2] === 93) {
+    // NOTE(@kitten): Microsoft virtual interface
+    return true;
+  } else {
+    return false;
+  }
+};
 
 export const interfaceAssignments = (): NetworkAssignment[] => {
   const candidates: NetworkAssignment[] = [];

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,7 +1,7 @@
 import { createSocket } from 'dgram';
 
-const NOOP_PORT = 65535;
-const NOOP_IP = '255.255.255.255';
+const PROBE_PORT = 53;
+const PROBE_IP = '1.1.1.1';
 const NO_ROUTE_IP = '0.0.0.0';
 
 class DefaultRouteError extends TypeError {
@@ -16,7 +16,7 @@ export const probeDefaultRoute = (): Promise<string> => {
       socket.close();
       socket.unref();
     });
-    socket.connect(NOOP_PORT, NOOP_IP, () => {
+    socket.connect(PROBE_PORT, PROBE_IP, () => {
       const address = socket.address();
       if (address && 'address' in address && address.address !== NO_ROUTE_IP) {
         resolve(address.address);


### PR DESCRIPTION
- Disregard virtual interfaces (Microsoft) by MAC
- Disregard virtual interfaces by name (`vEthernet`)
- Use public IP+port combo that's definitely publicly routable