### PR TITLE
fix: check subnet for dhcp discovery

### DIFF
--- a/.changeset/shaggy-walls-argue.md
+++ b/.changeset/shaggy-walls-argue.md
@@ -1,0 +1,5 @@
+---
+'lan-network': patch
+---
+
+Compare subnet-masked addresses before accepting DHCP discover message

--- a/src/__tests__/network.test.ts
+++ b/src/__tests__/network.test.ts
@@ -6,6 +6,7 @@ import {
   toIpStr,
   interfaceAssignments,
   matchAssignment,
+  isSameSubnet,
 } from '../network';
 
 describe(parseMacStr, () => {
@@ -30,6 +31,19 @@ describe(toIpStr, () => {
       expect(toIpStr(parseIpStr(addr))).toBe(addr);
     }
   );
+});
+
+describe(isSameSubnet, () => {
+  it('returns true for same subnet', () => {
+    expect(isSameSubnet('192.168.1.1', '192.168.1.2', '255.255.255.0')).toBe(
+      true
+    );
+  });
+  it('returns false for different subnet', () => {
+    expect(isSameSubnet('192.168.1.1', '192.168.2.1', '255.255.255.0')).toBe(
+      false
+    );
+  });
 });
 
 describe(interfaceAssignments, () => {

--- a/src/dhcp.ts
+++ b/src/dhcp.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { createSocket } from 'node:dgram';
-import { parseIpStr, toIpStr, parseMacStr } from './network';
+import { parseIpStr, toIpStr, parseMacStr, isSameSubnet } from './network';
 import type { NetworkAssignment } from './types';
 
 class DHCPTimeoutError extends TypeError {
@@ -57,6 +57,12 @@ export const dhcpDiscover = (
     const socket = createSocket(
       { type: 'udp4', reuseAddr: true },
       (_msg, rinfo) => {
+        if (
+          !isSameSubnet(rinfo.address, assignment.address, assignment.netmask)
+        ) {
+          return;
+        }
+
         clearTimeout(timeout);
         resolve(rinfo.address);
         socket.close();

--- a/src/network.ts
+++ b/src/network.ts
@@ -26,6 +26,17 @@ export const parseIpStr = (ipStr: string): number => {
   return addr[3] | (addr[2] << 8) | (addr[1] << 16) | (addr[0] << 24);
 };
 
+export const isSameSubnet = (
+  addrA: string,
+  addrB: string,
+  netmask: string
+): boolean => {
+  const rawAddrA = parseIpStr(addrA);
+  const rawAddrB = parseIpStr(addrB);
+  const rawMask = parseIpStr(netmask);
+  return (rawAddrA & rawMask) === (rawAddrB & rawMask);
+};
+
 export const toIpStr = (addr: number): string => {
   const MASK = (1 << 8) - 1;
   let ipStr = '';


### PR DESCRIPTION
The return order may be uncertain when we send DHCPDISCOVER packets to different network masks. This is a problem when I use Docker with the bridge interface.