### PR TITLE
fix: Mark `bridge*` interfaces as internal by default to deprioritize them

### DIFF
--- a/.changeset/social-islands-bet.md
+++ b/.changeset/social-islands-bet.md
@@ -1,0 +1,5 @@
+---
+'lan-network': patch
+---
+
+Deprioritize `bridge*` interfaces as internal networks

--- a/src/__tests__/network.test.ts
+++ b/src/__tests__/network.test.ts
@@ -116,6 +116,53 @@ describe(interfaceAssignments, () => {
       ]
     `);
   });
+
+  it('deprioritizes bridge interfaces', () => {
+    networkInterfaces.mockReturnValueOnce({
+      bridge0: [
+        {
+          address: '100.0.0.11',
+          netmask: '255.255.255.0',
+          family: 'IPv4',
+          mac: '10:00:00:00:00:00',
+          internal: false,
+          cidr: '',
+        },
+      ],
+      en1: [
+        {
+          address: '10.0.0.10',
+          netmask: '255.255.255.0',
+          family: 'IPv4',
+          mac: '10:00:00:00:00:00',
+          internal: false,
+          cidr: '',
+        },
+      ],
+    });
+    expect(interfaceAssignments()).toMatchInlineSnapshot(`
+      [
+        {
+          "address": "10.0.0.10",
+          "cidr": "",
+          "family": "IPv4",
+          "iname": "en1",
+          "internal": false,
+          "mac": "10:00:00:00:00:00",
+          "netmask": "255.255.255.0",
+        },
+        {
+          "address": "100.0.0.11",
+          "cidr": "",
+          "family": "IPv4",
+          "iname": "bridge0",
+          "internal": false,
+          "mac": "10:00:00:00:00:00",
+          "netmask": "255.255.255.0",
+        },
+      ]
+    `);
+  });
 });
 
 describe(matchAssignment, () => {

--- a/src/network.ts
+++ b/src/network.ts
@@ -67,8 +67,11 @@ export const isInternal = (assignment: NetworkAssignment) => {
   } else if (mac[0] === 0 && mac[1] === 21 && mac[2] === 93) {
     // NOTE(@kitten): Microsoft virtual interface
     return true;
-  } else if (assignment.iname.includes('vEthernet')) {
-    // NOTE(@kitten): Other Windows virtual interfaces
+  } else if (
+    assignment.iname.includes('vEthernet') ||
+    /^bridge\d+$/.test(assignment.iname)
+  ) {
+    // NOTE(@kitten): Other Windows virtual interfaces, or Linux bridge interfaces
     return true;
   } else {
     return false;


### PR DESCRIPTION
Resolves #14

Interfaces with an iname of `bridge\d+` should be deprioritized as they're likely not to be local networks. While I'm hesitant to add more rules based on name heuristics, this is likely the safest option. If this fails, it might be time to add a hardcoded list of interface names assigned to priorities.