### PR TITLE
fix: Add missing clean up on DHCP discover timeout

### DIFF
--- a/.changeset/smart-swans-add.md
+++ b/.changeset/smart-swans-add.md
@@ -1,0 +1,5 @@
+---
+'lan-network': patch
+---
+
+Add missing `socket.close` for DHCP discover on timeout

--- a/src/dhcp.ts
+++ b/src/dhcp.ts
@@ -53,6 +53,7 @@ export const dhcpDiscover = (
           `Received no reply to DHCPDISCOVER in ${DHCP_TIMEOUT}ms`
         )
       );
+      cleanup();
     }, DHCP_TIMEOUT);
     const socket = createSocket(
       { type: 'udp4', reuseAddr: true },
@@ -65,15 +66,17 @@ export const dhcpDiscover = (
 
         clearTimeout(timeout);
         resolve(rinfo.address);
-        socket.close();
-        socket.unref();
+        cleanup();
       }
     );
+    function cleanup() {
+      socket.close();
+      socket.unref();
+    }
     socket.on('error', error => {
       clearTimeout(timeout);
       reject(error);
-      socket.close();
-      socket.unref();
+      cleanup();
     });
     socket.bind(DHCP_CLIENT_PORT, () => {
       socket.setBroadcast(true);

--- a/src/dhcp.ts
+++ b/src/dhcp.ts
@@ -70,8 +70,10 @@ export const dhcpDiscover = (
       }
     );
     function cleanup() {
-      socket.close();
-      socket.unref();
+      try {
+        socket.close();
+        socket.unref();
+      } catch {}
     }
     socket.on('error', error => {
       clearTimeout(timeout);


### PR DESCRIPTION
Resolves #20 

## Summary

Adds missing code to close socket properly on timeout, which was missing before

## Set of changes

- Extract `cleanup` call for timeout on DHCP discover